### PR TITLE
Feat/earn license

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -74,4 +74,16 @@ class Facility
       false
     end
   end
+
+  def renew_drivers_license(registrant)
+    if @services.include?('Renew License')
+      if registrant.license_data[:license] == true
+        registrant.license_data[:renewed] = true
+      else
+        false
+      end
+    else
+      false
+    end
+  end
 end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -51,4 +51,16 @@ class Facility
     @collected_fees += fee
   end
 
+  def administer_written_test(registrant)
+    if @services.include?('Written Test')
+      if registrant.age < 16 || !registrant.permit?
+        false
+      else
+        registrant.license_data[:written] = true
+      end
+    else
+      false
+    end
+  end
+
 end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -63,4 +63,15 @@ class Facility
     end
   end
 
+  def administer_road_test(registrant)
+    if @services.include?('Road Test')
+      if registrant.license_data[:written] == true
+        registrant.license_data[:license] = true
+      else
+        false
+      end
+    else
+      false
+    end
+  end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -85,4 +85,63 @@ RSpec.describe Facility do
       expect(@bolt.registration_date).to be_an_instance_of(Date)
     end
   end
+
+  describe 'Earning full license' do
+    before(:each) do
+      @registrant_1 = Registrant.new('Bruce', 18, true )
+      @registrant_2 = Registrant.new('Penny', 16 )
+      @registrant_3 = Registrant.new('Tucker', 15 )
+      @facility_1 = Facility.new({name: 'DMV Tremont Branch', address: '2855 Tremont Place Suite 118 Denver CO 80205', phone: '(720) 865-4600'})
+      @facility_2 = Facility.new({name: 'DMV Northeast Branch', address: '4685 Peoria Street Suite 101 Denver CO 80239', phone: '(720) 865-4600'})
+    end
+    describe '#administer_written_test' do
+      it 'will not administer test if service is not offerered' do
+        expect(@registrant_1.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+        expect(@registrant_1.permit?).to be true
+        expect(@facility_1.administer_written_test(@registrant_1)).to be false
+        expect(@registrant_1.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+      end
+
+      it 'will administer test if service is offered' do
+        expect(@registrant_1.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+        @facility_1.add_service('Written Test')
+        expect(@facility_1.administer_written_test(@registrant_1)).to be true
+        expect(@registrant_1.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
+      end
+
+      it 'will not administer test if registrant has no permit' do
+        expect(@registrant_2.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+        expect(@registrant_2.age).to eq(16)
+        expect(@registrant_2.permit?).to eq(false)
+        @facility_1.add_service('Written Test')
+        expect(@facility_1.administer_written_test(@registrant_2)).to be false
+        expect(@registrant_2.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+        @registrant_2.earn_permit
+        expect(@facility_1.administer_written_test(@registrant_2)).to be true
+        expect(@registrant_2.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
+      end
+
+      it 'will not administer test if registrant is less than 16 years old' do
+        expect(@registrant_3.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+        expect(@registrant_3.age).to eq(15)
+        expect(@registrant_3.permit?).to eq(false)
+        @facility_1.add_service('Written Test')
+        expect(@facility_1.administer_written_test(@registrant_3)).to be false
+        expect(@registrant_3.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+        @registrant_3.earn_permit
+        expect(@facility_1.administer_written_test(@registrant_3)).to be false
+        expect(@registrant_3.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+      end
+
+    end
+
+    describe '#administer_road_test' do
+
+    end
+
+    describe '#renew_drivers_license' do
+
+    end
+  end
+
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -171,8 +171,43 @@ RSpec.describe Facility do
     end
 
     describe '#renew_drivers_license' do
+      it 'cannot renew license if service is not offered' do
+        @facility_1.add_service('Written Test')        
+        @facility_1.add_service('Road Test')
+        @facility_1.administer_written_test(@registrant_1)
+        @facility_1.administer_road_test(@registrant_1)
+        expect(@registrant_1.license_data).to eq({:written=>true, :license=>true, :renewed=>false})
+        expect(@facility_1.renew_drivers_license(@registrant_1)).to be false
+        expect(@registrant_1.license_data).to eq({:written=>true, :license=>true, :renewed=>false})
+      end
 
+      it 'can renew license if service is offered' do
+        @facility_1.add_service('Written Test')        
+        @facility_1.add_service('Road Test')
+        @facility_1.add_service('Renew License')
+        @facility_1.administer_written_test(@registrant_1)
+        @facility_1.administer_road_test(@registrant_1)
+        expect(@registrant_1.license_data).to eq({:written=>true, :license=>true, :renewed=>false})
+        expect(@facility_1.renew_drivers_license(@registrant_1)).to be true
+        expect(@registrant_1.license_data).to eq({:written=>true, :license=>true, :renewed=>false})
+      end
+
+      it 'cannot renew license without a drivers license' do
+        @facility_1.add_service('Written Test')        
+        @facility_1.add_service('Road Test')
+        @facility_1.add_service('Renew License')
+        expect(@registrant_2.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+        expect(@registrant_2.permit?).to be true
+        expect(@facility_1.renew_drivers_license(@registrant_2)).to be false
+        expect(@registrant_2.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+        @facility_1.administer_written_test(@registrant_2)
+        expect(@facility_1.renew_drivers_license(@registrant_2)).to be false
+        expect(@registrant_2.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
+        @facility_1.administer_road_test(@registrant_2)
+        expect(@registrant_2.license_data).to eq({:written=>true, :license=>true, :renewed=>false})
+        expect(@facility_1.renew_drivers_license(@registrant_2)).to be true
+        expect(@registrant_2.license_data).to eq({:written=>true, :license=>true, :renewed=>true})
+      end
     end
   end
-
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -189,13 +189,14 @@ RSpec.describe Facility do
         @facility_1.administer_road_test(@registrant_1)
         expect(@registrant_1.license_data).to eq({:written=>true, :license=>true, :renewed=>false})
         expect(@facility_1.renew_drivers_license(@registrant_1)).to be true
-        expect(@registrant_1.license_data).to eq({:written=>true, :license=>true, :renewed=>false})
+        expect(@registrant_1.license_data).to eq({:written=>true, :license=>true, :renewed=>true})
       end
 
       it 'cannot renew license without a drivers license' do
         @facility_1.add_service('Written Test')        
         @facility_1.add_service('Road Test')
         @facility_1.add_service('Renew License')
+        @registrant_2.earn_permit
         expect(@registrant_2.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
         expect(@registrant_2.permit?).to be true
         expect(@facility_1.renew_drivers_license(@registrant_2)).to be false

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -136,7 +136,38 @@ RSpec.describe Facility do
     end
 
     describe '#administer_road_test' do
+      it 'cannot administer road test if service is not offered' do
+        @facility_1.add_service('Written Test')
+        @facility_1.administer_written_test(@registrant_1)
+        expect(@registrant_1.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
+        expect(@registrant_1.permit?).to be true
+        expect(@facility_1.administer_road_test(@registrant_1)).to be false
+        expect(@registrant_1.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
+      end
 
+      it 'can administer road test if service is offered' do
+        @facility_1.add_service('Written Test')
+        @facility_1.administer_written_test(@registrant_1)
+        expect(@registrant_1.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
+        expect(@registrant_1.permit?).to be true
+        @facility_1.add_service('Road Test')
+        expect(@facility_1.administer_road_test(@registrant_1)).to be true
+        expect(@registrant_1.license_data).to eq({:written=>true, :license=>true, :renewed=>false})
+      end
+
+      it 'will not administer a road test if written test has not been taken' do
+        @facility_1.add_service('Written Test')
+        @facility_1.add_service('Road Test')
+        @registrant_2.earn_permit
+        expect(@registrant_2.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+        expect(@registrant_2.permit?).to be true
+        expect(@facility_1.administer_road_test(@registrant_2)).to be false
+        expect(@registrant_2.license_data).to eq({:written=>false, :license=>false, :renewed=>false})
+        @facility_1.administer_written_test(@registrant_2)
+        expect(@registrant_2.license_data).to eq({:written=>true, :license=>false, :renewed=>false})
+        expect(@facility_1.administer_road_test(@registrant_2)).to be true
+        expect(@registrant_2.license_data).to eq({:written=>true, :license=>true, :renewed=>false})
+      end
     end
 
     describe '#renew_drivers_license' do


### PR DESCRIPTION
Add the ability for facilities :
Administer written tests given that registrants meet the requirements
Administer road tests and grant a driver's license given that registrants meet the requirements
Renew licenses given that registrants meet the requirements

These tasks can only be performed if the facility offers that service.